### PR TITLE
Update icon codepoints to work with nerdfonts v3

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -36,7 +36,7 @@ function setup()
   -- File = '',
   -- Folder = '',
   xplr.config.node_types.directory.meta.icon = blue ""
-  xplr.config.node_types.file.meta.icon = cyan ""
+  xplr.config.node_types.file.meta.icon = cyan "󰈔"
   xplr.config.node_types.symlink.meta.icon = magenta ""
 
   -- ["jpeg"] = {
@@ -58,32 +58,32 @@ function setup()
   --
   xplr.config.node_types.mime_essence = {
     audio = {
-      ["*"] = { meta = { icon = yellow "" } },
+      ["*"] = { meta = { icon = yellow "󰎈" } },
     },
     video = {
-      ["*"] = { meta = { icon = "ﳜ" } },
+      ["*"] = { meta = { icon = "󰟞" } },
     },
     image = {
       ["*"] = { meta = { icon = "" } },
     },
     application = {
       -- application/zip
-      zip = { meta = { icon = "" } },
+      zip = { meta = { icon = "󰀼" } },
     },
     text = {
-      ["*"] = { meta = { icon = "" } },
+      ["*"] = { meta = { icon = "󰈙" } },
     },
   }
 
   -- nnn https://github.com/jarun/nnn/blob/master/src/icons-nerdfont.h
-  xplr.config.node_types.special["Desktop"] = { meta = { icon = "ﲾ" } }
-  xplr.config.node_types.special["Documents"] = { meta = { icon = "" } }
-  xplr.config.node_types.special["Downloads"] = { meta = { icon = "" } }
+  xplr.config.node_types.special["Desktop"] = { meta = { icon = "󰟀" } }
+  xplr.config.node_types.special["Documents"] = { meta = { icon = "󰃖" } }
+  xplr.config.node_types.special["Downloads"] = { meta = { icon = "󰃘" } }
   xplr.config.node_types.special["Music"] = { meta = { icon = "" } }
-  xplr.config.node_types.special["Pictures"] = { meta = { icon = "" } }
+  xplr.config.node_types.special["Pictures"] = { meta = { icon = "󰉔" } }
   -- xplr.config.node_types.special["Public"] = { meta = { icon = "" } }
-  xplr.config.node_types.special["Templates"] = { meta = { icon = "陼" } }
-  xplr.config.node_types.special["Videos"] = { meta = { icon = "" } }
+  xplr.config.node_types.special["Templates"] = { meta = { icon = "󰗇" } }
+  xplr.config.node_types.special["Videos"] = { meta = { icon = "󰈰" } }
 
   -- https://github.com/kyazdani42/nvim-web-devicons/blob/master/README.md
   xplr.config.node_types.special["Gemfile"] = { meta = { icon = "" } }
@@ -119,31 +119,31 @@ function setup()
 
   --- nnn
   xplr.config.node_types.extension.m3u = { meta = { icon = "" } }
-  xplr.config.node_types.extension["7z"] = { meta = { icon = "" } }
-  xplr.config.node_types.extension.apk = { meta = { icon = "" } }
-  xplr.config.node_types.extension.bz2 = { meta = { icon = "" } }
-  xplr.config.node_types.extension.cab = { meta = { icon = "" } }
-  xplr.config.node_types.extension.cbr = { meta = { icon = "" } }
-  xplr.config.node_types.extension.cbr = { meta = { icon = "" } }
-  xplr.config.node_types.extension.cbz = { meta = { icon = "" } }
-  xplr.config.node_types.extension.cpio = { meta = { icon = "" } }
-  xplr.config.node_types.extension.gz = { meta = { icon = "" } }
-  xplr.config.node_types.extension.gzip = { meta = { icon = "" } }
-  xplr.config.node_types.extension.lha = { meta = { icon = "" } }
-  xplr.config.node_types.extension.lzh = { meta = { icon = "" } }
-  xplr.config.node_types.extension.lzma = { meta = { icon = "" } }
-  xplr.config.node_types.extension.rar = { meta = { icon = "" } }
-  xplr.config.node_types.extension.rpm = { meta = { icon = "" } }
-  xplr.config.node_types.extension.tar = { meta = { icon = "" } }
-  xplr.config.node_types.extension.tgz = { meta = { icon = "" } }
-  xplr.config.node_types.extension.txz = { meta = { icon = "" } }
-  xplr.config.node_types.extension.xbps = { meta = { icon = "" } }
-  xplr.config.node_types.extension.xz = { meta = { icon = "" } }
-  xplr.config.node_types.extension.zip = { meta = { icon = "" } }
+  xplr.config.node_types.extension["7z"] = { meta = { icon = "󰀼" } }
+  xplr.config.node_types.extension.apk = { meta = { icon = "󰀼" } }
+  xplr.config.node_types.extension.bz2 = { meta = { icon = "󰀼" } }
+  xplr.config.node_types.extension.cab = { meta = { icon = "󰀼" } }
+  xplr.config.node_types.extension.cbr = { meta = { icon = "󰀼" } }
+  xplr.config.node_types.extension.cbr = { meta = { icon = "󰀼" } }
+  xplr.config.node_types.extension.cbz = { meta = { icon = "󰀼" } }
+  xplr.config.node_types.extension.cpio = { meta = { icon = "󰀼" } }
+  xplr.config.node_types.extension.gz = { meta = { icon = "󰀼" } }
+  xplr.config.node_types.extension.gzip = { meta = { icon = "󰀼" } }
+  xplr.config.node_types.extension.lha = { meta = { icon = "󰀼" } }
+  xplr.config.node_types.extension.lzh = { meta = { icon = "󰀼" } }
+  xplr.config.node_types.extension.lzma = { meta = { icon = "󰀼" } }
+  xplr.config.node_types.extension.rar = { meta = { icon = "󰀼" } }
+  xplr.config.node_types.extension.rpm = { meta = { icon = "󰀼" } }
+  xplr.config.node_types.extension.tar = { meta = { icon = "󰀼" } }
+  xplr.config.node_types.extension.tgz = { meta = { icon = "󰀼" } }
+  xplr.config.node_types.extension.txz = { meta = { icon = "󰀼" } }
+  xplr.config.node_types.extension.xbps = { meta = { icon = "󰀼" } }
+  xplr.config.node_types.extension.xz = { meta = { icon = "󰀼" } }
+  xplr.config.node_types.extension.zip = { meta = { icon = "󰀼" } }
 
   --- devicons
   xplr.config.node_types.extension.COPYING = { meta = { icon = "" } }
-  xplr.config.node_types.extension.R = { meta = { icon = "ﳒ" } }
+  xplr.config.node_types.extension.R = { meta = { icon = "󰟔" } }
   xplr.config.node_types.extension.Rmd = { meta = { icon = "" } }
   xplr.config.node_types.extension.ai = { meta = { icon = "" } }
   xplr.config.node_types.extension.awk = { meta = { icon = "" } }
@@ -161,7 +161,7 @@ function setup()
   xplr.config.node_types.extension.conf = { meta = { icon = "" } }
   xplr.config.node_types.extension.cp = { meta = { icon = "" } }
   xplr.config.node_types.extension.cpp = { meta = { icon = "" } }
-  xplr.config.node_types.extension.cs = { meta = { icon = "" } }
+  xplr.config.node_types.extension.cs = { meta = { icon = "󰌛" } }
   xplr.config.node_types.extension.csh = { meta = { icon = "" } }
   xplr.config.node_types.extension.cson = { meta = { icon = "" } }
   xplr.config.node_types.extension.css = { meta = { icon = "" } }
@@ -171,7 +171,7 @@ function setup()
   xplr.config.node_types.extension.db = { meta = { icon = "" } }
   xplr.config.node_types.extension.desktop = { meta = { icon = "" } }
   xplr.config.node_types.extension.diff = { meta = { icon = "" } }
-  xplr.config.node_types.extension.doc = { meta = { icon = "" } }
+  xplr.config.node_types.extension.doc = { meta = { icon = "󰈬" } }
   xplr.config.node_types.extension.dockerfile = { meta = { icon = "" } }
   xplr.config.node_types.extension.dropbox = { meta = { icon = "" } }
   xplr.config.node_types.extension.dump = { meta = { icon = "" } }
@@ -223,7 +223,7 @@ function setup()
   xplr.config.node_types.extension.lock = { meta = { icon = red "" } }
   xplr.config.node_types.extension.lua = { meta = { icon = blue "" } }
   xplr.config.node_types.extension.markdown = { meta = { icon = "" } }
-  xplr.config.node_types.extension.material = { meta = { icon = "" } }
+  xplr.config.node_types.extension.material = { meta = { icon = "󰔉" } }
   xplr.config.node_types.extension.md = { meta = { icon = yellow "" } }
   xplr.config.node_types.extension.mdx = { meta = { icon = "" } }
   xplr.config.node_types.extension.mjs = { meta = { icon = "" } }
@@ -231,7 +231,7 @@ function setup()
   xplr.config.node_types.extension.mli = { meta = { icon = "λ" } }
   xplr.config.node_types.extension.mustache = { meta = { icon = "" } }
   xplr.config.node_types.extension.nix = { meta = { icon = "" } }
-  xplr.config.node_types.extension.opus = { meta = { icon = "" } }
+  xplr.config.node_types.extension.opus = { meta = { icon = "󰈣" } }
   xplr.config.node_types.extension.otf = { meta = { icon = "" } }
   xplr.config.node_types.extension.pck = { meta = { icon = "" } }
   xplr.config.node_types.extension.php = { meta = { icon = "" } }
@@ -239,7 +239,7 @@ function setup()
   xplr.config.node_types.extension.pm = { meta = { icon = "" } }
   xplr.config.node_types.extension.png = { meta = { icon = "" } }
   xplr.config.node_types.extension.pp = { meta = { icon = "" } }
-  xplr.config.node_types.extension.ppt = { meta = { icon = "" } }
+  xplr.config.node_types.extension.ppt = { meta = { icon = "󰈧" } }
   xplr.config.node_types.extension.procfile = { meta = { icon = "" } }
   xplr.config.node_types.extension.ps1 = { meta = { icon = "" } }
   xplr.config.node_types.extension.psb = { meta = { icon = "" } }
@@ -248,13 +248,13 @@ function setup()
   xplr.config.node_types.extension.pyc = { meta = { icon = "" } }
   xplr.config.node_types.extension.pyd = { meta = { icon = "" } }
   xplr.config.node_types.extension.pyo = { meta = { icon = "" } }
-  xplr.config.node_types.extension.r = { meta = { icon = "ﳒ" } }
+  xplr.config.node_types.extension.r = { meta = { icon = "󰟔" } }
   xplr.config.node_types.extension.rake = { meta = { icon = "" } }
   xplr.config.node_types.extension.rakefile = { meta = { icon = "" } }
   xplr.config.node_types.extension.rb = { meta = { icon = "" } }
   xplr.config.node_types.extension.rlib = { meta = { icon = "" } }
   xplr.config.node_types.extension.rmd = { meta = { icon = "" } }
-  xplr.config.node_types.extension.rproj = { meta = { icon = "鉶" } }
+  xplr.config.node_types.extension.rproj = { meta = { icon = "󰗆" } }
   xplr.config.node_types.extension.rs = { meta = { icon = red "" } }
   xplr.config.node_types.extension.rss = { meta = { icon = "" } }
   xplr.config.node_types.extension.sass = { meta = { icon = "" } }
@@ -267,24 +267,24 @@ function setup()
   xplr.config.node_types.extension.styl = { meta = { icon = "" } }
   xplr.config.node_types.extension.suo = { meta = { icon = "" } }
   xplr.config.node_types.extension.svelte = { meta = { icon = "" } }
-  xplr.config.node_types.extension.svg = { meta = { icon = "ﰟ" } }
+  xplr.config.node_types.extension.svg = { meta = { icon = "󰜡" } }
   xplr.config.node_types.extension.swift = { meta = { icon = "" } }
   xplr.config.node_types.extension.t = { meta = { icon = "" } }
   xplr.config.node_types.extension.terminal = { meta = { icon = "" } }
-  xplr.config.node_types.extension.tex = { meta = { icon = "ﭨ" } }
+  xplr.config.node_types.extension.tex = { meta = { icon = "󰙩" } }
   xplr.config.node_types.extension.toml = { meta = { icon = white "" } }
   xplr.config.node_types.extension.tres = { meta = { icon = "" } }
   xplr.config.node_types.extension.ts = { meta = { icon = "" } }
-  xplr.config.node_types.extension.tscn = { meta = { icon = "" } }
+  xplr.config.node_types.extension.tscn = { meta = { icon = "󰎁" } }
   xplr.config.node_types.extension.tsx = { meta = { icon = "" } }
   xplr.config.node_types.extension.twig = { meta = { icon = "" } }
   xplr.config.node_types.extension.vim = { meta = { icon = "" } }
-  xplr.config.node_types.extension.vue = { meta = { icon = "﵂" } }
+  xplr.config.node_types.extension.vue = { meta = { icon = "󰡄" } }
   xplr.config.node_types.extension.webmanifest = { meta = { icon = "" } }
-  xplr.config.node_types.extension.webpack = { meta = { icon = "ﰩ" } }
+  xplr.config.node_types.extension.webpack = { meta = { icon = "󰜫" } }
   xplr.config.node_types.extension.xcplayground = { meta = { icon = "" } }
-  xplr.config.node_types.extension.xls = { meta = { icon = "" } }
-  xplr.config.node_types.extension.xml = { meta = { icon = "謹" } }
+  xplr.config.node_types.extension.xls = { meta = { icon = "󰈛" } }
+  xplr.config.node_types.extension.xml = { meta = { icon = "󰗀" } }
   xplr.config.node_types.extension.xul = { meta = { icon = "" } }
   xplr.config.node_types.extension.yaml = { meta = { icon = "" } }
   xplr.config.node_types.extension.yml = { meta = { icon = "" } }


### PR DESCRIPTION
This change requires nerdfonts v2.3 or later.

Conversion was done based on this table:
https://ohmyposh.dev/codepoints.csv